### PR TITLE
Fix newlines in auth header

### DIFF
--- a/lib/ruby_vcloud_sdk/connection/connection.rb
+++ b/lib/ruby_vcloud_sdk/connection/connection.rb
@@ -31,7 +31,7 @@ module VCloudSdk
 
       def connect(username, password)
         login_password = "#{username}:#{password}"
-        auth_header_value = "Basic #{Base64.encode64(login_password)}"
+        auth_header_value = "Basic #{Base64.strict_encode64(login_password)}"
         response = @site[login_url].post("",
             Authorization: auth_header_value, Accept: ACCEPT)
         Config.logger.debug(response)


### PR DESCRIPTION
Using Base64.strict_encode64 to avoid extra newlines getting added to the Auth Header.
